### PR TITLE
Consolidated LaTeX example.

### DIFF
--- a/canvas_cc_gem_course.rb
+++ b/canvas_cc_gem_course.rb
@@ -37,6 +37,15 @@ course.grading_standards = [gs]
   course.assignments << assignment
 end
 
+page = CanvasCc::CanvasCC::Models::Page.new
+page.workflow_state = "active"
+page.page_name = "Latex Example"
+page.body = "<p>When \\(a \\ne 0\\), there are two
+solutions to \\(ax^2 + bx + c = 0\\) and they are
+\\(x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}.\\)</p>"
+page.identifier = new_identifier
+course.pages << page
+
 dir = Dir.mktmpdir
 output_file = CanvasCc::CanvasCC::CartridgeCreator.new(course).create(dir)
 puts output_file


### PR DESCRIPTION
Let's generate various examples from `canvas_cc` for testing the CCV. Specifically, we can create a LaTex examples and abandon the `latex.imscc` file in the CCV repo. Here is a good example of LaTeX on a wiki page.

<img width="389" alt="latex" src="https://github.com/woodie/sample-course/assets/17495/38eedbad-04c6-44d1-b86e-9d5801df5e15">
